### PR TITLE
Hidden lower bar from SmartLink

### DIFF
--- a/Addins/SmartLink/SmartLink.Web/Content/App.css
+++ b/Addins/SmartLink/SmartLink.Web/Content/App.css
@@ -284,7 +284,7 @@ ul, li {
     width: 100%;
     height: 60px;
     padding: 6px 20px 0px 20px;
-    display: table;
+    display: none;
     position: fixed;
     z-index: 100;
     bottom: 0;


### PR DESCRIPTION
hidden lower bar as it takes space away and it is not needed for proposal manager